### PR TITLE
Add support for OSM relations

### DIFF
--- a/create_output_files.py
+++ b/create_output_files.py
@@ -109,45 +109,45 @@ for dist in districts:
     <table>
         <tr>
             <td style='color: #4daf4a;'>
-                OSM nodes/ways with valid fhrs:id and matching addr:postcode or
+                OSM objects with valid fhrs:id and matching addr:postcode or
                 not:addr:postcode</td>
             <td>""" + str(dist['stats']['matched']) + """</td>
             <td></td>
         </tr>
         <tr>
             <td><span style='color: #c03ca5;'>
-                Relevant OSM nodes/ways with postcode but no valid fhrs:id</span></td>
+                Relevant OSM objects with postcode but no valid fhrs:id</span></td>
             <td>""" + str(dist['stats']['OSM_with_postcode']) + """</td>
             <td><a href="gpx/osm-unmatched-with-postcode-""" +
                 str(dist['id']) + """.gpx" download>GPX</a></td>
         </tr>
         <tr>
             <td style='color: #ff7f00;'>
-                Relevant OSM nodes/ways without postcode or fhrs:id</td>
+                Relevant OSM objects without postcode or fhrs:id</td>
             <td>""" + str(dist['stats']['OSM_no_postcode']) + """</td>
             <td><a href="gpx/osm-unmatched-no-postcode-""" +
                 str(dist['id']) + """.gpx" download>GPX</a></td>
         </tr>
             <tr>
             <td style='color: #e31a1c;'>
-                OSM nodes/ways with valid fhrs:id but mismatched/missing postcode</td>
+                OSM objects with valid fhrs:id but mismatched/missing postcode</td>
             <td>""" + str(dist['stats']['matched_postcode_error']) + """</td>
             <td></td>
         </tr>
         <tr>
-            <td style='color: #e31a1c;'>OSM nodes/ways with invalid fhrs:id</td>
+            <td style='color: #e31a1c;'>OSM objects with invalid fhrs:id</td>
             <td>""" + str(dist['stats']['mismatch']) + """</td>
             <td><a href="gpx/osm-invalid-fhrsid-""" +
                 str(dist['id']) + """.gpx" download>GPX</a></td>
         </tr>
         <tr>
-            <td style='color: #007fff;'>FHRS establishments with no matching OSM node/way</td>
+            <td style='color: #007fff;'>FHRS establishments with no matching OSM object</td>
             <td>""" + str(dist['stats']['FHRS']) + """</td>
             <td><a href="gpx/fhrs-unmatched-""" +
                 str(dist['id']) + """.gpx" download>GPX</a></td>
         </tr>
         <tr>
-            <td>Total number of relevant OSM nodes/ways</td>
+            <td>Total number of relevant OSM objects</td>
             <td>""" + str(dist['stats']['total_OSM']) + """</td>
             <td></td>
         </tr>
@@ -162,14 +162,14 @@ for dist in districts:
             <td></td>
         </tr>
         <tr>
-            <td>Percentage of relevant OSM nodes/ways with a postcode**</td>
+            <td>Percentage of relevant OSM objects with a postcode**</td>
             <td>""" + '%.1f' % dist['stats']['OSM_matched_or_postcode_pc'] + """%</td>
             <td></td>
         </tr>
     </table>
-    <p style="font-size: 80%">*A match is considered successful when the OSM node/way's fhrs:id
+    <p style="font-size: 80%">*A match is considered successful when the OSM objects's fhrs:id
     matches an FHRS one and the OSM addr:postcode or not:addr:postcode matches the FHRS one.</p>
-    <p style="font-size: 80%">**OSM nodes/ways with an addr:postcode or not:addr:postcode that
+    <p style="font-size: 80%">**OSM objects with an addr:postcode or not:addr:postcode that
     matches the FHRS postcode, or with an addr:postcode but no fhrs:id tag.</p>
 
     <h3>Overview</h3>
@@ -525,9 +525,9 @@ html = ("""
 
 <h2>Districts</h2>
 
-<p style="font-size: 80%">Matched: % of FHRS establishments matched to an OSM node/way using
+<p style="font-size: 80%">Matched: % of FHRS establishments matched to an OSM object using
 the fhrs:id tag. N.B. the OSM addr:postcode or not:addr:postcode must match the FHRS one.</p>
-<p style="font-size: 80%">Postcodes: % of OSM nodes/ways with an addr:postcode or not:addr:postcode
+<p style="font-size: 80%">Postcodes: % of OSM objects with an addr:postcode or not:addr:postcode
 that matches the FHRS one or with an addr:postcode tag and no fhrs:id tag.</p>
 
 <table>

--- a/fhrs_osm/__init__.py
+++ b/fhrs_osm/__init__.py
@@ -6,6 +6,7 @@ import urllib2
 import xml.etree.ElementTree
 from xml.sax.saxutils import escape
 from shapely.geometry import Polygon
+from shapely.geometry import MultiPoint
 from time import sleep
 
 
@@ -850,16 +851,11 @@ class OSMDataset(object):
         # tag/value list
         query += '(\n'
         for this in self.tag_value_list:
-            query += '\tnode["' + this['t'] + '"="' + this['v'] + '"];\n'
-            query += '\tway["' + this['t'] + '"="' + this['v'] + '"];\n'
-            # TODO: not supporting relations until we can parse them properly
-            # query += '\trelation["' + this['t'] + '"="' + this['v'] + '"];\n\n'
+            query += '\tnwr["' + this['t'] + '"="' + this['v'] + '"];\n'
+
         # tag exists list
         for this in self.tag_exists_list:
-            query += '\tnode["' + this + '"];\n'
-            query += '\tway["' + this + '"];\n'
-            # TODO: not supporting relations until we can parse them properly
-            # query += '\trelation["' + this + '"];\n\n'
+            query += '\tnwr["' + this + '"];\n'
 
         query += ');\n'
 
@@ -908,6 +904,8 @@ class OSMDataset(object):
             record['type'] = 'node'
         elif (type(entity) == overpy.Way):
             record['type'] = 'way'
+        elif (type(entity) == overpy.Relation):
+            record['type'] = 'relation'
 
         # start with this record's tags set to None
         for this_field in fields_to_check:
@@ -971,19 +969,34 @@ class OSMDataset(object):
                     break
 
         for way in result.get_ways():
+            # if filter_ways is True:
+            # iterate through this way's tags/values
+            for tag, value in way.tags.iteritems():
+                # if this tag/value or tag match our criteria
+                if {'t': tag, 'v': value} in self.tag_value_list or tag in self.tag_exists_list:
+                    # write to DB and stop checking this way's tags/values
+                    centroid = self.get_way_centroid(way)
+                    self.write_entity(entity=way, lat=centroid['lat'],
+                                      lon=centroid['lon'], connection=connection)
+                    break
+            # else:
+            #     centroid = self.get_way_centroid(way)
+            #     self.write_entity(entity=way, lat=centroid['lat'],
+            #                       lon=centroid['lon'], connection=connection)
+
+        for relation in result.get_relations():
             if filter_ways is True:
-                # iterate through this way's tags/values
-                for tag, value in way.tags.iteritems():
+                for tag, value in relation.tags.iteritems():
                     # if this tag/value or tag match our criteria
                     if {'t': tag, 'v': value} in self.tag_value_list or tag in self.tag_exists_list:
-                        # write to DB and stop checking this way's tags/values
-                        centroid = self.get_way_centroid(way)
-                        self.write_entity(entity=way, lat=centroid['lat'],
-                                          lon=centroid['lon'], connection=connection)
+                        # write to DB and stop checking this relation's tags/values
+                        centroid = self.get_relation_centroid(relation)
+                        self.write_entity(entity=relation, lat=centroid['lat'],
+                                      lon=centroid['lon'], connection=connection)
                         break
             else:
-                centroid = self.get_way_centroid(way)
-                self.write_entity(entity=way, lat=centroid['lat'],
+                centroid = self.get_relation_centroid(relation)
+                self.write_entity(entity=relation, lat=centroid['lat'],
                                   lon=centroid['lon'], connection=connection)
 
         cur = connection.cursor()
@@ -1015,6 +1028,29 @@ class OSMDataset(object):
             return {'lat': way.nodes[0].lat, 'lon': way.nodes[0].lon}
         else:
             raise RuntimeError
+
+    def get_relation_centroid(self, relation):
+        """Calculate a representative centre-point for a relation
+
+        relation (object): overpy.Relation object
+        Returns dict of lat/lon
+        """
+        geom = []
+        for member in relation.members:
+            if isinstance(member, overpy.RelationWay):
+                way = member.resolve()
+                for node in way.nodes:
+                    geom.append((node.lon, node.lat))
+            elif isinstance(member, overpy.RelationNode):
+                node = member.resolve()
+                geom.append((node.lon, node.lat))
+
+        if len(geom) > 0:
+            mp = MultiPoint(geom)
+            bbox = mp.bounds
+            return {'lat': 0.5*(bbox[1]+bbox[3]), 'lon': 0.5*(bbox[0]+bbox[2])}
+        else:
+            return {'lat': 0, 'lon': 0}
 
 
 class FHRSDataset(object):

--- a/filter-osm.sh
+++ b/filter-osm.sh
@@ -20,6 +20,16 @@ fi
 
 $osmosis_bin \
   --read-pbf $input_pbf \
+  --tf accept-relations fhrs:id=* \
+  --used-way \
+  --used-node outPipe.0="relations-fhrsid" \
+  \
+  --read-pbf $input_pbf \
+  --tf accept-relations $filter_list \
+  --used-way \
+  --used-node outPipe.0="relations-filter" \
+  \
+  --read-pbf $input_pbf \
   --tf accept-ways fhrs:id=* \
   --tf reject-relations \
   --used-node outPipe.0="ways-fhrsid" \
@@ -39,7 +49,9 @@ $osmosis_bin \
   --tf reject-ways \
   --tf reject-relations outPipe.0="nodes-filter" \
   \
+  --merge inPipe.0="relations-fhrsid" inPipe.1="relations-filter" \
   --merge inPipe.0="ways-fhrsid" inPipe.1="ways-filter" \
+  --merge \
   --merge inPipe.0="nodes-fhrsid" inPipe.1="nodes-filter" \
   --merge \
   --write-xml data/filtered.osm


### PR DESCRIPTION
Relations are now included in the Overpass and XML data fetches. A representative location is computed for each by taking the centre of the bounding box of the relation's child nodes and ways.

One drawback with the approach taken is that ways must now always be filtered (since any present might be relation children, rather that being of interest themselves). I don't know how much of a performance hit this will be on the whole UK data. A way round this would be to fetch the data in three separate parts -- one each for the nodes, ways (with their child notes) and relations (with their child nodes and relations). No post-fetch filtering would then be needed.